### PR TITLE
Fix failing pipeline caused by outdated mvn version at 3-alpine image

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'maven:3.5.4-jdk-8-slim'
+            image 'maven:3.5.4-alpine'
             args '-v /root/.m2:/root/.m2'
         }
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'maven:3-alpine'
+            image 'maven:3.5.4-jdk-8-slim'
             args '-v /root/.m2:/root/.m2'
         }
     }


### PR DESCRIPTION
Since maven requirements were updated to be at least 3.5.4 at the master branch and the `3-alpine` image uses 3.5.0, it should be updated.

Tested and works:
![Screen Shot 2022-03-19 at 23 10 08](https://user-images.githubusercontent.com/11563691/159138494-694e95d2-6edc-4ff3-b788-7c09c8ee0693.png)

