### PR TITLE
Use Maven 3.5.4 in Jenkinsfile

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'maven:3-alpine'
+            image 'maven:3.5.4-alpine'
             args '-v /root/.m2:/root/.m2'
         }
     }


### PR DESCRIPTION
#264 enforces Maven 3.5.4 during build, but Jenkinsfile requires only Maven 3.

This commit ensures that Jenkins uses Maven 3.5.4, fixing possible build issues.