### PR TITLE
fix Maven version issue 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.8.6,)</version>
+                  <version>[3.6.3,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[11,)</version>


### PR DESCRIPTION
Detected Maven Version: 3.6.3 is not in the allowed range [3.8.6,).

This issue happened to me and found many facing it in this course:
https://udemy.com/course/jenkins-masterclass/learn/lecture/23845088#questions/18852402