### PR TITLE
Bump docker image to 3.9.0

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'maven:3-alpine'
+            image 'maven:3.9.0'
             args '-v /root/.m2:/root/.m2'
         }
     }


### PR DESCRIPTION
Let's pull the official and maintained docker image. -alpine hasn't been distributed within the past 6 years.