### PR TITLE
Simplify deliver.sh

### DIFF
--- a/jenkins/scripts/deliver.sh
+++ b/jenkins/scripts/deliver.sh
@@ -8,16 +8,16 @@ set -x
 mvn jar:jar install:install help:evaluate -Dexpression=project.name
 set +x
 
-echo 'The following complex command extracts the value of the <name/> element'
+echo 'The following command extracts the value of the <name/> element'
 echo 'within <project/> of your Java/Maven project''s "pom.xml" file.'
 set -x
-NAME=`mvn help:evaluate -Dexpression=project.name | grep "^[^\[]"`
+NAME=`mvn -q -DforceStdout help:evaluate -Dexpression=project.name`
 set +x
 
-echo 'The following complex command behaves similarly to the previous one but'
+echo 'The following command behaves similarly to the previous one but'
 echo 'extracts the value of the <version/> element within <project/> instead.'
 set -x
-VERSION=`mvn help:evaluate -Dexpression=project.version | grep "^[^\[]"`
+VERSION=`mvn -q -DforceStdout help:evaluate -Dexpression=project.version`
 set +x
 
 echo 'The following command runs and outputs the execution of your Java'


### PR DESCRIPTION
## Simplify deliver.sh with Apache Maven options

Avoid separate processing of the output since Apache Maven already includes an example that recommends the technique for cases like:

```
  RESULT=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
  echo $RESULT
```

https://maven.apache.org/plugins/maven-help-plugin/evaluate-mojo.html is the Apache Maven documentation that includes the example.
