### PR TITLE
Require Java 11 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.13.0</version>
+          <configuration>
+            <release>11</release>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
## Require Java 11 or newer

Jenkins stopped supporting Java 8 a long time ago.  Let's use Java 11 or newer.

Confirmed that this compiles without warning or error using Java 11, Java 17, and Java 21 with Apache Maven 3.8.6 and Apache Maven 3.9.6.

The tutorial is already running Jenkins with a newer Java version, so there is not much motivation to attempt to keep this sample repository at Java 8.  This removes the warning message that the Java 8 source setting will be removed from a future release of Apache Maven.
