### PR TITLE
Require Java 17 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.8.6,)</version>
+                  <version>[3.9.2,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[17,)</version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.13.0</version>
           <configuration>
-            <release>11</release>
+            <release>17</release>
           </configuration>
         </plugin>
       </plugins>
@@ -63,7 +63,7 @@
                   <version>[3.8.6,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[11,)</version>
+                  <version>[17,)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
## Require Java 17 or newer

- **Require Java 17 or newer**
- **Require a Apache Maven version released in last 12 months**

## Testing done

Confirmed that the docker compose configuration that  uses this tutorial is already delivering Apache Maven 3.9.7 with Java 17.0.11.