### PR TITLE
Define Maven Tool in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage('Build') { 
+            steps {
+                sh 'mvn -B -DskipTests clean package' 
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
     agent any
+    tools {
+        maven 'Maven 3.9.2' // This should match the name in Global Tool Configuration
+    }
     stages {
         stage('Build') { 
             steps {


### PR DESCRIPTION
- [ ] This is used to specify the Maven tool by referring to its configured name (e.g., Maven 3.9.2) in the Jenkinsfile using the tool directive