### PR TITLE
chore: Updated minimum required versions for Maven and Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.9.2,)</version>
+                  <version>[3.6.3,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[17,)</version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,10 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.6.3,)</version>
+                  <version>[3.9.9,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[17,)</version>
+                  <version>[21,)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
## Summary 

- **Chores**
  - Updated minimum required versions for Maven and Java. Maven 3.9.9 and Java 21 are now required to build the project.

## Walkthrough

The Maven Enforcer Plugin configuration was updated to enforce higher minimum versions for both Maven (from 3.9.2 to 3.9.9) and Java (from 17 to 21) in the project's build file. No other build or plugin settings were changed.